### PR TITLE
add mastodon-modern theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ yarn-debug.log
 
 # Ignore Docker option files
 docker-compose.override.yml
+
+# ignore mastodon-modern style files as the dev does not want it to end up on github
+/app/javascript/styles/modern/modern.css
+/app/javascript/flavours/glitch/styles/modern/modern.css
+/app/javascript/flavours/glitch/styles/modern/glitch-fixes.css

--- a/app/javascript/flavours/glitch/styles/modern-contrast.scss
+++ b/app/javascript/flavours/glitch/styles/modern-contrast.scss
@@ -1,0 +1,5 @@
+@import 'contrast';
+@import 'index';
+@import 'modern/modern';
+@import 'modern/glitch-fixes';
+@import 'contrast/diff';

--- a/app/javascript/flavours/glitch/styles/modern-dark.scss
+++ b/app/javascript/flavours/glitch/styles/modern-dark.scss
@@ -1,0 +1,4 @@
+@import 'variables';
+@import 'index';
+@import 'modern/modern';
+@import 'modern/glitch-fixes';

--- a/app/javascript/flavours/glitch/styles/modern-light.scss
+++ b/app/javascript/flavours/glitch/styles/modern-light.scss
@@ -1,0 +1,5 @@
+@import 'mastodon-light/variables';
+@import 'index';
+@import 'modern/modern';
+@import 'modern/glitch-fixes';
+@import 'mastodon-light/diff';

--- a/app/javascript/skins/glitch/modern-contrast/common.scss
+++ b/app/javascript/skins/glitch/modern-contrast/common.scss
@@ -1,0 +1,1 @@
+@import 'flavours/glitch/styles/modern-contrast';

--- a/app/javascript/skins/glitch/modern-contrast/names.yml
+++ b/app/javascript/skins/glitch/modern-contrast/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    glitch:
+      modern-contrast: Modern (high contrast)

--- a/app/javascript/skins/glitch/modern-dark/common.scss
+++ b/app/javascript/skins/glitch/modern-dark/common.scss
@@ -1,0 +1,1 @@
+@import 'flavours/glitch/styles/modern-dark';

--- a/app/javascript/skins/glitch/modern-dark/names.yml
+++ b/app/javascript/skins/glitch/modern-dark/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    glitch:
+      modern-dark: Modern (dark)

--- a/app/javascript/skins/glitch/modern-light/common.scss
+++ b/app/javascript/skins/glitch/modern-light/common.scss
@@ -1,0 +1,1 @@
+@import 'flavours/glitch/styles/modern-light';

--- a/app/javascript/skins/glitch/modern-light/names.yml
+++ b/app/javascript/skins/glitch/modern-light/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    glitch:
+      modern-light: Modern (light)

--- a/app/javascript/skins/vanilla/modern-contrast/common.scss
+++ b/app/javascript/skins/vanilla/modern-contrast/common.scss
@@ -1,0 +1,1 @@
+@import 'styles/modern-contrast';

--- a/app/javascript/skins/vanilla/modern-contrast/names.yml
+++ b/app/javascript/skins/vanilla/modern-contrast/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    vanilla:
+      modern-contrast: Modern (high contrast)

--- a/app/javascript/skins/vanilla/modern-dark/common.scss
+++ b/app/javascript/skins/vanilla/modern-dark/common.scss
@@ -1,0 +1,1 @@
+@import 'styles/modern-dark';

--- a/app/javascript/skins/vanilla/modern-dark/names.yml
+++ b/app/javascript/skins/vanilla/modern-dark/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    vanilla:
+      modern-dark: Modern (dark)

--- a/app/javascript/skins/vanilla/modern-light/common.scss
+++ b/app/javascript/skins/vanilla/modern-light/common.scss
@@ -1,0 +1,1 @@
+@import 'styles/modern-light';

--- a/app/javascript/skins/vanilla/modern-light/names.yml
+++ b/app/javascript/skins/vanilla/modern-light/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    vanilla:
+      modern-light: Modern (light)

--- a/app/javascript/styles/modern-contrast.scss
+++ b/app/javascript/styles/modern-contrast.scss
@@ -1,0 +1,9 @@
+@import 'contrast/variables';
+@import 'application';
+@import 'modern/modern';
+@import 'contrast/diff';
+
+.layout-multiple-columns .column {
+  flex-grow: 1;
+  max-width: 500px;
+}

--- a/app/javascript/styles/modern-dark.scss
+++ b/app/javascript/styles/modern-dark.scss
@@ -1,0 +1,8 @@
+@import 'mastodon/variables';
+@import 'application';
+@import 'modern/modern';
+
+.layout-multiple-columns .column {
+  flex-grow: 1;
+  max-width: 500px;
+}

--- a/app/javascript/styles/modern-light.scss
+++ b/app/javascript/styles/modern-light.scss
@@ -1,0 +1,9 @@
+@import 'mastodon-light/variables';
+@import 'application';
+@import 'modern/modern';
+@import 'mastodon-light/diff';
+
+.layout-multiple-columns .column {
+  flex-grow: 1;
+  max-width: 500px;
+}

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -16,10 +16,46 @@ namespace :assets do
 
     render_static_page 'errors/500', layout: 'error', dest: Rails.public_path.join('assets', '500.html')
   end
+
+  desc "Fetch mastodon-modern CSS"
+  task fetch_modern_css: :environment do
+    # workaround because maintainer of mastodon-modern does not like their code being on github
+    require "faraday"
+
+    base_url = "https://codeberg.org/Freeplay/Mastodon-Modern/raw/commit/%<commit>s/%<filename>s"
+    commit = "7444eaef9edcf89f2f6c3c5586e0bb93f090fe1d"
+    {
+      "modern.css" => %w[
+        app/javascript/styles/modern/modern.css
+        app/javascript/flavours/glitch/styles/modern/modern.css
+      ],
+      "glitch-fixes.css" => %w[
+        app/javascript/flavours/glitch/styles/modern/glitch-fixes.css
+      ],
+    }.each do |filename, destinations|
+      url = format(base_url, commit:, filename:)
+
+      puts "Fetching #{url}"
+      response = Faraday.get(url)
+      unless response.success?
+        warn "not successful due to #{response.reason_phrase.inspect}, skipping"
+        next
+      end
+
+      content = response.body.force_encoding("UTF-8")
+      destinations.each do |destination|
+        path = Rails.root.join(destination)
+        puts "Writing #{destination}"
+        File.open(destination, "w") do |f|
+          f.puts content
+        end
+      end
+    end
+  end
 end
 
 if Rake::Task.task_defined?('assets:precompile')
-  Rake::Task['assets:precompile'].enhance do
+  Rake::Task['assets:precompile'].enhance(["assets:fetch_modern_css"]) do
     Webpacker.manifest.refresh
     Rake::Task['assets:generate_static_pages'].invoke
   end


### PR DESCRIPTION
from https://codeberg.org/Freeplay/Mastodon-Modern

as the developer does not want that code to end up on github one needs to run `rake assets:fetch_modern_css` in order to fetch the actual style (this is done automatically before the `assets:precompile` task)